### PR TITLE
Remove Cargo.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,0 @@
-[[package]]
-name = "extsort"
-version = "0.1.0"
-


### PR DESCRIPTION
According to [The Cargo Book](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html), Cargo.lock needn't be tracked when building a library.